### PR TITLE
Warning fixes

### DIFF
--- a/lib/win32ole/utils.rb
+++ b/lib/win32ole/utils.rb
@@ -75,7 +75,7 @@ class WIN32OLE
           tdocs = type_lib.get_documentation(i)
           return type_lib.get_type_info(i) if tdocs.name == docs.name
         rescue ComFailException => e
-          # We continue on failure. 
+          # We continue on failure.
         end
       end
       type_info # Actually MRI seems like it could fail in weird case
@@ -99,7 +99,7 @@ class WIN32OLE
         info = typelib.get_type_info(i)
         next unless info
         yield info, docs
-      end      
+      end
     end
 
     def all_vars(typeinfo)
@@ -111,7 +111,7 @@ class WIN32OLE
         name = names[0]
         next unless name
         yield desc, name
-      end      
+      end
     end
 
     def reg_each_key_for(reg, subkey, &block)
@@ -121,13 +121,13 @@ class WIN32OLE
     end
 
     # Walks all guid/clsid entries and yields every single version
-    # of those entries to the supplied block. See search_registry as 
+    # of those entries to the supplied block. See search_registry as
     # an example of its usage.
     def typelib_registry_each_guid_version
-      Win32::Registry::HKEY_CLASSES_ROOT.open('TypeLib') do |reg| 
+      Win32::Registry::HKEY_CLASSES_ROOT.open('TypeLib') do |reg|
         reg.each_key do |guid, wtime|
           reg.open(guid) do |guid_reg|
-            guid_reg.each_key do |version_string, wtime|
+            guid_reg.each_key do |version_string, time|
               version = version_string.to_f
               begin
                 guid_reg.open(version_string) do |version_reg|

--- a/lib/win32ole/win32ole_event.rb
+++ b/lib/win32ole/win32ole_event.rb
@@ -20,12 +20,12 @@ class WIN32OLE_EVENT
   end
 
   # Defines the callback event. If argument is omitted, this method defines the callback of all events.
-  # 
+  #
   #  ie = WIN32OLE.new('InternetExplorer.Application')
   #  ev = WIN32OLE_EVENT.new(ie)
   #  ev.on_event("NavigateComplete") {|url| puts url}
   #  ev.on_event() {|ev, *args| puts "#{ev} fired"}
-  # 
+  #
   def on_event(name=nil, &block)
     if name
       @event_handlers[name.to_s] = block
@@ -33,9 +33,9 @@ class WIN32OLE_EVENT
       @default_handler = block
     end
   end
-  
+
   # removes the callback of event.
-  # 
+  #
   #   ie = WIN32OLE.new('InternetExplorer.Application')
   #   ev = WIN32OLE_EVENT.new(ie)
   #   ev.on_event('BeforeNavigate2') {|*args|
@@ -44,7 +44,7 @@ class WIN32OLE_EVENT
   #     ...
   #   ev.off_event('BeforeNavigate2')
   #     ...
-  # 
+  #
   def off_event(name=nil)
     if name.nil?
       @event_handlers.clear
@@ -54,7 +54,7 @@ class WIN32OLE_EVENT
     else
       raise TypeError.new("wrong argument type (expected String or Symbol)")
     end
-    
+
     nil
   end
 
@@ -62,7 +62,7 @@ class WIN32OLE_EVENT
     name = name.to_s
     handler = @event_handlers[name]
     if handler
-      handler.call *args
+      handler.call(*args)
     elsif @default_handler
       @default_handler.call name, *args
     end

--- a/lib/win32ole/win32ole_type.rb
+++ b/lib/win32ole/win32ole_type.rb
@@ -1,11 +1,11 @@
 class WIN32OLE_TYPE
   java_import org.racob.com.TypeInfo
-  
+
   attr_reader :typeinfo
 
   def initialize(*args)
     case args.length
-    when 2 then 
+    when 2 then
       typelib_name, olename = SafeStringValue(args[0]), SafeStringValue(args[1])
       @typelib = WIN32OLE_TYPELIB.new(typelib_name) # Internal call
       find_all_typeinfo(@typelib.typelib) do |info, docs|
@@ -97,7 +97,7 @@ class WIN32OLE_TYPE
   def to_s
     name
   end
-  
+
   def variables
     variables = []
     all_vars(@typeinfo) do |desc, name|
@@ -125,7 +125,7 @@ class WIN32OLE_TYPE
       Win32::Registry::HKEY_CLASSES_ROOT.open('CLSID') do |reg|
         reg.each_key do |clsid, wtime|
           reg.open(clsid) do |clsid_reg|
-            clsid_reg.each_key do |key, wtime|
+            clsid_reg.each_key do |key, time|
               name = nil
               if key == "ProgID"
                 clsid_reg.open(key) {|key_reg| name = key_reg.read(nil)[1] }


### PR DESCRIPTION
This fixes some warnings with 1.9. It also includes some whitespace stripping, courtesy of gvim.
